### PR TITLE
Migrate scripts from wikitools to mwclient

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,11 +1,11 @@
 import time, datetime, urllib, json, warnings, re, mwparserfromhell
-from wikitools import *
+import mwclient
 import login #Bot password
 
-site = wiki.Wiki() #Tell Python to use the English Wikipedia's API
-site.login(login.username, login.password) #login
+site = mwclient.Site('en.wikipedia.org', path='/w/')
+site.login(login.username, login.password)
 
-#routine to autoswitch some of the output - as filenames in, say, filep.unprefixedtitle have accented chars!
+#routine to autoswitch some of the output - as filenames in, say, filep.name have accented chars!
 def pnt(s):
     try:
         print(s)
@@ -22,21 +22,19 @@ def findpages():
               'cmtitle':'Category:Non-free files with orphaned versions more than 7 days old',
               'cmlimit':'500'
               }
-    req = api.APIRequest(site, params) #Set the API request
-    res = req.query(False) #Send the API request and store the result in res
-    touse = pagelist.listFromQuery(site, res['query']['categorymembers']) #Make a list
+    res = site.api(**params)
+    touse = [site.pages[cm['title']] for cm in res['query']['categorymembers']]
     return touse
 
 def versiontodelete(page):
     params = {'action':'query',
               'prop':'imageinfo',
-              'titles':page.unprefixedtitle,
+              'titles':page.name,
               'iiprop':'archivename',
               'iilimit':'max',
               'formatversion':'2',
               }
-    req = api.APIRequest(site, params)
-    res = req.query(False)
+    res = site.api(**params)
     whattodel = res['query']['pages'][0]['imageinfo'][1:] #Go into specifics, ignore first result (DatBot's reduced version)
     for result in whattodel:
         if 'filehidden' in result:
@@ -50,25 +48,25 @@ def versiontodelete(page):
     return whattodel
 
 def deletefile(page, version, token):
-    params = {'action':'revisiondelete',
-              'target':page.unprefixedtitle,
+    params = {
+              'action':'revisiondelete',
+              'target':page.name,
               'type':'oldimage',
               'hide':'content',
               'ids':version,
               'token':token,
-              'reason':'Orphaned non-free file revision(s) deleted per [[WP:F5|F5]] ([[User:AmandaNP/Imagerevdel/Run|disable]])'
+              'reason':'Orphaned non-free file revision(s) deleted per [[WP:F5|F5]] ([[User:AmandaNP/Imagerevdel/Run|disable]])',
               }
-    api.APIRequest(site, params).query() #Actually delete it  (DO NOT UNCOMMENT UNTIL BOT IS APPROVED)
+    site.post(**params) #Actually delete it  (DO NOT UNCOMMENT UNTIL BOT IS APPROVED)
     return #Stop the function, ready for the next
 
 def abusechecks(page):
     params = {'action':'query',
               'prop':'revisions',
-              'titles':page.unprefixedtitle,
+              'titles':page.name,
               'rvlimit':'10'
               }
-    req = api.APIRequest(site, params)
-    res = req.query(False)
+    res = site.api(**params)
     pageid = next(iter(res['query']['pages']))
     revisions=res['query']['pages'][pageid]['revisions']
     #print revisions
@@ -97,12 +95,11 @@ def abusechecks(page):
 def checksize(page):
     params = {'action':'query',
               'prop':'imageinfo',
-              'titles':page.unprefixedtitle,
+              'titles':page.name,
               'formatversion':'2',
               'iiprop':'size'
               }
-    req = api.APIRequest(site, params)
-    res = req.query(False)
+    res = site.api(**params)
     pixel = res['query']['pages'][0]['imageinfo'][0]['width'] * res['query']['pages'][0]['imageinfo'][0]['height']
     if pixel > 105000:
     #if (res['query']['pages'][0]['imageinfo'][0]['width'] > 400) and (res['query']['pages'][0]['imageinfo'][0]['height'] > 400):
@@ -124,7 +121,7 @@ def main():
         if tobreak == "yes":
             break
         try: #Try to delete the old revision(s)
-            if filep.unprefixedtitle == "Category:Non-free files with orphaned versions more than 7 days old needing human review": #Skip category thing
+            if filep.name == "Category:Non-free files with orphaned versions more than 7 days old needing human review": #Skip category thing
                 continue
             todelete = versiontodelete(filep)
             firstversion="yes"
@@ -135,53 +132,51 @@ def main():
                     tobreak = "yes"
                     break
                 if firstversion == "yes":
-                    pagepage = page.Page(site, filep.unprefixedtitle) #Hacky workaround since File and Page are different types in the module
-                    pagetext = pagepage.getWikiText() 
+                    pagepage = site.pages[filep.name]
+                    pagetext = pagepage.text()
                     #Stop if there's nobots
                     allow_bots(pagetext, "DeltaQuadBot")
-                    skipcategories = page.Page(site, 'User:RonBot/1/FreeCategory').getWikiText().split("|")
+                    skipcategories = site.pages['User:RonBot/1/FreeCategory'].text().split("|")
                     check = abusechecks(filep) #Check if file was uploaded 2 days ago
-                    if any(skipcategory in pagepage.getCategories() for skipcategory in skipcategories):
+                    if any(skipcategory in [cat.name for cat in pagepage.categories()] for skipcategory in skipcategories):
                         print("One of the potentially free categories were found. Skipping.")
                         check="free"
                     if check == "No":
                         if pagetext.find('|human=yes')>0:break#Manual already set - no more to do
-                        pagetext = addmanual(pagetext,filep.unprefixedtitle)
-                        pagepage.edit(text=pagetext, bot=True, summary="(Image Revdel) Requesting manual review ([[User:AmandaNP/Imagerevdel/Run|disable]])") #(DO NOT UNCOMMENT UNTIL BOT IS APPROVED)
+                        pagetext = addmanual(pagetext,filep.name)
+                        pagepage.edit(text=pagetext, summary="(Image Revdel) Requesting manual review ([[User:AmandaNP/Imagerevdel/Run|disable]])", bot=True) #(DO NOT UNCOMMENT UNTIL BOT IS APPROVED)
                         break #- leave for loop as we only want one entry - there may be multple versions to delete
                     if check == "free":
                         if pagetext.find('|human=yes')>0:break#Manual already set - no more to do
-                        pagetext = addmanual(pagetext,filep.unprefixedtitle)
-                        pagepage.edit(text=pagetext, bot=True, summary="(Image Revdel) Requesting manual review - Free file conflict ([[User:AmandaNP/Imagerevdel/Run|disable]])") #(DO NOT UNCOMMENT UNTIL BOT IS APPROVED)
+                        pagetext = addmanual(pagetext,filep.name)
+                        pagepage.edit(text=pagetext, summary="(Image Revdel) Requesting manual review - Free file conflict ([[User:AmandaNP/Imagerevdel/Run|disable]])", bot=True) #(DO NOT UNCOMMENT UNTIL BOT IS APPROVED)
                         break #- leave for loop as we only want one entry - there may be multple versions to delete
                     if  (filep) == "Manual":
                         if pagetext.find('|human=yes')>0:break#Manual already set - no more to do
-                        pagetext = addmanual(pagetext,filep.unprefixedtitle)
-                        pagepage.edit(text=pagetext, bot=True, summary="(Image Revdel) Requesting manual review ([[User:AmandaNP/Imagerevdel/Run|disable]])") #(DO NOT UNCOMMENT UNTIL BOT IS APPROVED)
+                        pagetext = addmanual(pagetext,filep.name)
+                        pagepage.edit(text=pagetext, summary="(Image Revdel) Requesting manual review ([[User:AmandaNP/Imagerevdel/Run|disable]])", bot=True) #(DO NOT UNCOMMENT UNTIL BOT IS APPROVED)
                         break #- leave for loop as we only want one entry - there may be multple versions to delete
-                #Get a token
-                params = { 'action':'query', 'meta':'tokens' }
-                token = api.APIRequest(site, params).query()['query']['tokens']['csrftoken']
+                token = site.tokens['csrf']
                 #Delete the revision
                 deletefile(filep, version, token)
                 #Remove tag
                 pagetext = re.sub(r'\n*\{\{(?:[Oo]rphaned non-free revisions|[Nn]on-free reduced).*}}', '', pagetext)
                 pagetext=pagetext.lstrip()
-                pagepage.edit(text=pagetext, bot=True, summary="(Image Revdel) Orphaned non-free file(s) deleted per [[WP:F5|F5]] ([[User:AmandaNP/Imagerevdel/Run|disable]])") #(DO NOT UNCOMMENT UNTIL BOT IS APPROVED)
-                pnt ("Revdel complete for %s" % filep.unprefixedtitle) #For debugging
+                pagepage.edit(text=pagetext, summary="(Image Revdel) Orphaned non-free file(s) deleted per [[WP:F5|F5]] ([[User:AmandaNP/Imagerevdel/Run|disable]])", bot=True) #(DO NOT UNCOMMENT UNTIL BOT IS APPROVED)
+                pnt ("Revdel complete for %s" % filep.name) #For debugging
                 firstversion="no"
             else:
-                pagepage = page.Page(site, filep.unprefixedtitle) #Hacky workaround since File and Page are different types in the module
-                pagetext = pagepage.getWikiText() 
+                pagepage = site.pages[filep.name]
+                pagetext = pagepage.text()
                 pagetext = re.sub(r'\n*\{\{(?:[Oo]rphaned non-free revisions|[Nn]on-free reduced).*}}', '', pagetext)
                 pagetext=pagetext.lstrip()
-                pagepage.edit(text=pagetext, bot=True, summary="(Image Revdel) Remove banner - nothing to delete ([[User:AmandaNP/Imagerevdel/Run|disable]])") #(DO NOT UNCOMMENT UNTIL BOT IS APPROVED)
+                pagepage.edit(text=pagetext, summary="(Image Revdel) Remove banner - nothing to delete ([[User:AmandaNP/Imagerevdel/Run|disable]])", bot=True) #(DO NOT UNCOMMENT UNTIL BOT IS APPROVED)
 
         except Exception as e: #If there's an error, ignore the file
             print(e)
             pass
 def startAllowed():
-    textpage = page.Page(site, "User:AmandaNP/Imagerevdel/Run").getWikiText()
+    textpage = site.pages["User:AmandaNP/Imagerevdel/Run"].text()
     if textpage == "Run":
         return "run"
     else:

--- a/reverse.py
+++ b/reverse.py
@@ -1,11 +1,11 @@
 import time, datetime, urllib, json, warnings, re, mwparserfromhell
-from wikitools import *
+import mwclient
 import login #Bot password
 
-site = wiki.Wiki() #Tell Python to use the English Wikipedia's API
-site.login(login.username, login.password) #login
+site = mwclient.Site('en.wikipedia.org', path='/w/')
+site.login(login.username, login.password)
 
-#routine to autoswitch some of the output - as filenames in, say, filep.unprefixedtitle have accented chars!
+#routine to autoswitch some of the output - as filenames in, say, filep.name have accented chars!
 def pnt(s):
     try:
         print(s)
@@ -23,21 +23,19 @@ def findpages():
               'cmdir':'desc',
               'cmlimit':'500'
               }
-    req = api.APIRequest(site, params) #Set the API request
-    res = req.query(False) #Send the API request and store the result in res
-    touse = pagelist.listFromQuery(site, res['query']['categorymembers']) #Make a list
+    res = site.api(**params)
+    touse = [site.pages[cm['title']] for cm in res['query']['categorymembers']]
     return touse
 
 def versiontodelete(page):
     params = {'action':'query',
               'prop':'imageinfo',
-              'titles':page.unprefixedtitle,
+              'titles':page.name,
               'iiprop':'archivename',
               'iilimit':'max',
               'formatversion':'2',
               }
-    req = api.APIRequest(site, params)
-    res = req.query(False)
+    res = site.api(**params)
     whattodel = res['query']['pages'][0]['imageinfo'][1:] #Go into specifics, ignore first result (DatBot's reduced version)
     for result in whattodel:
          if 'filehidden' in result:
@@ -50,25 +48,25 @@ def versiontodelete(page):
     return whattodel
 
 def deletefile(page, version, token):
-    params = {'action':'revisiondelete',
-              'target':page.unprefixedtitle,
+    params = {
+              'action':'revisiondelete',
+              'target':page.name,
               'type':'oldimage',
               'hide':'content',
               'ids':version,
               'token':token,
-              'reason':'Orphaned non-free file revision(s) deleted per [[WP:F5|F5]] ([[User:AmandaNP/Imagerevdel/Run|disable]])'
+              'reason':'Orphaned non-free file revision(s) deleted per [[WP:F5|F5]] ([[User:AmandaNP/Imagerevdel/Run|disable]])',
               }
-    api.APIRequest(site, params).query() #Actually delete it  (DO NOT UNCOMMENT UNTIL BOT IS APPROVED)
+    site.post(**params) #Actually delete it  (DO NOT UNCOMMENT UNTIL BOT IS APPROVED)
     return #Stop the function, ready for the next
 
 def abusechecks(page):
     params = {'action':'query',
               'prop':'revisions',
-              'titles':page.unprefixedtitle,
+              'titles':page.name,
               'rvlimit':'10'
               }
-    req = api.APIRequest(site, params)
-    res = req.query(False)
+    res = site.api(**params)
     pageid = next(iter(res['query']['pages']))
     revisions=res['query']['pages'][pageid]['revisions']
     #print revisions
@@ -97,12 +95,11 @@ def abusechecks(page):
 def checksize(page):
     params = {'action':'query',
               'prop':'imageinfo',
-              'titles':page.unprefixedtitle,
+              'titles':page.name,
               'formatversion':'2',
               'iiprop':'size'
               }
-    req = api.APIRequest(site, params)
-    res = req.query(False)
+    res = site.api(**params)
     pixel = res['query']['pages'][0]['imageinfo'][0]['width'] * res['query']['pages'][0]['imageinfo'][0]['height']
     if pixel > 105000:
     #if (res['query']['pages'][0]['imageinfo'][0]['width'] > 400) and (res['query']['pages'][0]['imageinfo'][0]['height'] > 400):
@@ -124,7 +121,7 @@ def main():
         if tobreak == "yes":
             break
         try: #Try to delete the old revision(s)
-            if filep.unprefixedtitle == "Category:Non-free files with orphaned versions more than 7 days old needing human review": #Skip category thing
+            if filep.name == "Category:Non-free files with orphaned versions more than 7 days old needing human review": #Skip category thing
                 continue
             todelete = versiontodelete(filep)
             firstversion="yes"
@@ -135,53 +132,51 @@ def main():
                     tobreak = "yes"
                     break
                 if firstversion == "yes":
-                    pagepage = page.Page(site, filep.unprefixedtitle) #Hacky workaround since File and Page are different types in the module
-                    pagetext = pagepage.getWikiText() 
+                    pagepage = site.pages[filep.name]
+                    pagetext = pagepage.text()
                     #Stop if there's nobots
                     allow_bots(pagetext, "DeltaQuadBot")
-                    skipcategories = page.Page(site, 'User:RonBot/1/FreeCategory').getWikiText().split("|")
+                    skipcategories = site.pages['User:RonBot/1/FreeCategory'].text().split("|")
                     check = abusechecks(filep) #Check if file was uploaded 2 days ago
-                    if any(skipcategory in pagepage.getCategories() for skipcategory in skipcategories):
+                    if any(skipcategory in [cat.name for cat in pagepage.categories()] for skipcategory in skipcategories):
                         print("One of the potentially free categories were found. Skipping.")
                         check="free"
                     if check == "No":
                         if pagetext.find('|human=yes')>0:break#Manual already set - no more to do
-                        pagetext = addmanual(pagetext,filep.unprefixedtitle)
-                        pagepage.edit(text=pagetext, bot=True, summary="(Image Revdel) Requesting manual review ([[User:AmandaNP/Imagerevdel/Run|disable]])") #(DO NOT UNCOMMENT UNTIL BOT IS APPROVED)
+                        pagetext = addmanual(pagetext,filep.name)
+                        pagepage.edit(text=pagetext, summary="(Image Revdel) Requesting manual review ([[User:AmandaNP/Imagerevdel/Run|disable]])", bot=True) #(DO NOT UNCOMMENT UNTIL BOT IS APPROVED)
                         break #- leave for loop as we only want one entry - there may be multple versions to delete
                     if check == "free":
                         if pagetext.find('|human=yes')>0:break#Manual already set - no more to do
-                        pagetext = addmanual(pagetext,filep.unprefixedtitle)
-                        pagepage.edit(text=pagetext, bot=True, summary="(Image Revdel) Requesting manual review - Free file conflict ([[User:AmandaNP/Imagerevdel/Run|disable]])") #(DO NOT UNCOMMENT UNTIL BOT IS APPROVED)
+                        pagetext = addmanual(pagetext,filep.name)
+                        pagepage.edit(text=pagetext, summary="(Image Revdel) Requesting manual review - Free file conflict ([[User:AmandaNP/Imagerevdel/Run|disable]])", bot=True) #(DO NOT UNCOMMENT UNTIL BOT IS APPROVED)
                         break #- leave for loop as we only want one entry - there may be multple versions to delete
                     if  (filep) == "Manual":
                         if pagetext.find('|human=yes')>0:break#Manual already set - no more to do
-                        pagetext = addmanual(pagetext,filep.unprefixedtitle)
-                        pagepage.edit(text=pagetext, bot=True, summary="(Image Revdel) Requesting manual review ([[User:AmandaNP/Imagerevdel/Run|disable]])") #(DO NOT UNCOMMENT UNTIL BOT IS APPROVED)
+                        pagetext = addmanual(pagetext,filep.name)
+                        pagepage.edit(text=pagetext, summary="(Image Revdel) Requesting manual review ([[User:AmandaNP/Imagerevdel/Run|disable]])", bot=True) #(DO NOT UNCOMMENT UNTIL BOT IS APPROVED)
                         break #- leave for loop as we only want one entry - there may be multple versions to delete
-                #Get a token
-                params = { 'action':'query', 'meta':'tokens' }
-                token = api.APIRequest(site, params).query()['query']['tokens']['csrftoken']
+                token = site.tokens['csrf']
                 #Delete the revision
                 deletefile(filep, version, token)
                 #Remove tag
                 pagetext = re.sub(r'\n*\{\{(?:[Oo]rphaned non-free revisions|[Nn]on-free reduced).*}}', '', pagetext)
                 pagetext=pagetext.lstrip()
-                pagepage.edit(text=pagetext, bot=True, summary="(Image Revdel) Orphaned non-free file(s) deleted per [[WP:F5|F5]] ([[User:AmandaNP/Imagerevdel/Run|disable]])") #(DO NOT UNCOMMENT UNTIL BOT IS APPROVED)
-                pnt ("Revdel complete for %s" % filep.unprefixedtitle) #For debugging
+                pagepage.edit(text=pagetext, summary="(Image Revdel) Orphaned non-free file(s) deleted per [[WP:F5|F5]] ([[User:AmandaNP/Imagerevdel/Run|disable]])", bot=True) #(DO NOT UNCOMMENT UNTIL BOT IS APPROVED)
+                pnt ("Revdel complete for %s" % filep.name) #For debugging
                 firstversion="no"
             else:
-                pagepage = page.Page(site, filep.unprefixedtitle) #Hacky workaround since File and Page are different types in the module
-                pagetext = pagepage.getWikiText() 
+                pagepage = site.pages[filep.name]
+                pagetext = pagepage.text()
                 pagetext = re.sub(r'\n*\{\{(?:[Oo]rphaned non-free revisions|[Nn]on-free reduced).*}}', '', pagetext)
                 pagetext=pagetext.lstrip()
-                pagepage.edit(text=pagetext, bot=True, summary="(Image Revdel) Remove banner - nothing to delete ([[User:AmandaNP/Imagerevdel/Run|disable]])") #(DO NOT UNCOMMENT UNTIL BOT IS APPROVED)
+                pagepage.edit(text=pagetext, summary="(Image Revdel) Remove banner - nothing to delete ([[User:AmandaNP/Imagerevdel/Run|disable]])", bot=True) #(DO NOT UNCOMMENT UNTIL BOT IS APPROVED)
 
         except Exception as e: #If there's an error, ignore the file
             print(e)
             pass
 def startAllowed():
-    textpage = page.Page(site, "User:AmandaNP/Imagerevdel/Run").getWikiText()
+    textpage = site.pages["User:AmandaNP/Imagerevdel/Run"].text()
     if textpage == "Run":
         return "run"
     else:


### PR DESCRIPTION
## Summary
- replace wikitools with mwclient and initialize connection via `mwclient.Site`
- switch API requests to `site.api` and revision deletions to `site.post`
- use `site.pages` objects with `text()` and `edit()` for page operations and fetch CSRF tokens from `site.tokens`
- explicitly set the `revisiondelete` action when posting deletion requests

## Testing
- `python -m py_compile main.py reverse.py`


------
https://chatgpt.com/codex/tasks/task_e_68a82168ebd0832fa082cdc67f6f5f32